### PR TITLE
approve: fix github comment message and allow to customize

### DIFF
--- a/pkg/cmd/approve/approve.go
+++ b/pkg/cmd/approve/approve.go
@@ -28,6 +28,8 @@ type approveOptions struct {
 	config      *config.PatchManagerConfig
 	configFile  string
 	comment     bool
+	skipComment string
+	pickComment string
 }
 
 // NewApproveCommand creates a render command.
@@ -58,8 +60,10 @@ func (r *approveOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&r.githubToken, "github-token", "", "Github Access Token (GITHUB_TOKEN env variable)")
 	fs.StringVarP(&r.inFile, "file", "f", "", "Set input file to read the list of candidates")
 	fs.BoolVar(&r.force, "force", false, "Do not ask stupid questions and ship it")
-	fs.BoolVar(&r.comment, "add-comment", false, "Provide informative comment about decision to all pull requests")
 	fs.StringVar(&r.configFile, "config", os.Getenv("PATCHMANAGER_CONFIG"), "Path to a config file (PATCHMANAGER_CONFIG env variable)")
+	fs.BoolVar(&r.comment, "add-comment", false, "Provide informative comment about decision to all pull requests")
+	fs.StringVar(&r.skipComment, "skip-comment", "", "Message to include in all skipped pull requests")
+	fs.StringVar(&r.pickComment, "pick-comment", "", "Message to include in all picked pull requests")
 }
 
 func (r *approveOptions) Validate() error {
@@ -103,29 +107,61 @@ Do you wish to continue? (y/n): `, r.config.MergeWindowConfig.From, r.config.Mer
 	return nil
 }
 
+func approvedPRs(prs v1.ApprovedCandidateList) []v1.ApprovedCandidate {
+	result := []v1.ApprovedCandidate{}
+	for i := range prs.Items {
+		if prs.Items[i].PullRequest.Decision != "pick" {
+			continue
+		}
+		result = append(result, prs.Items[i])
+	}
+	return result
+}
+
+func skippedPRs(prs v1.ApprovedCandidateList) []v1.ApprovedCandidate {
+	result := []v1.ApprovedCandidate{}
+	for i := range prs.Items {
+		if prs.Items[i].PullRequest.Decision != "skip" {
+			continue
+		}
+		result = append(result, prs.Items[i])
+	}
+	return result
+}
+
 func (r *approveOptions) Run(ctx context.Context) error {
 	content, err := ioutil.ReadFile(r.inFile)
 	if err != nil {
 		return err
 	}
 
-	var approved v1.ApprovedCandidateList
+	var prs v1.ApprovedCandidateList
 
-	if err := yaml.Unmarshal(content, &approved); err != nil {
+	if err := yaml.Unmarshal(content, &prs); err != nil {
 		return err
+	}
+
+	approved := approvedPRs(prs)
+	skipped := skippedPRs(prs)
+	if len(approved) == 0 && len(skipped) == 0 {
+		return nil
 	}
 
 	approver := github.NewPullRequestApprover(ctx, r.githubToken)
 
 	if !r.force {
-		fmt.Fprintf(os.Stdout, "Following Pull Requests will get cherry-pick-approved label:\n\n")
-		for _, pr := range approved.Items {
-			if pr.PullRequest.Decision != "pick" {
-				continue
+		if len(approved) > 0 {
+			fmt.Fprintf(os.Stdout, "Pull requests cherry-pick-prs:\n\n")
+			for _, pr := range approved {
+				fmt.Fprintf(os.Stdout, "* [%0.2f] %s\n", pr.PullRequest.Score, pr.PullRequest.URL)
 			}
-			fmt.Fprintf(os.Stdout, "* %s\n", pr.PullRequest.URL)
 		}
-
+		if len(skipped) > 0 {
+			fmt.Fprintf(os.Stdout, "\nPull requests skipped:\n\n")
+			for _, pr := range skipped {
+				fmt.Fprintf(os.Stdout, "* [%0.2f] %s\n", pr.PullRequest.Score, pr.PullRequest.URL)
+			}
+		}
 		fmt.Fprintf(os.Stdout, "\nDo you want to continue? (y/n)? ")
 		if !util.AskForConfirmation() {
 			return nil
@@ -133,35 +169,49 @@ func (r *approveOptions) Run(ctx context.Context) error {
 		fmt.Fprint(os.Stdout, "\n")
 	}
 
-	for _, pr := range approved.Items {
-		if pr.PullRequest.Decision != "pick" {
-			if r.comment {
-				if err := approver.Comment(ctx, pr.PullRequest.URL, fmt.Sprintf(`
-This pull request was not picked by patch manager for the current z-stream window (%s-%s).
-
-Score: %.02f
-Reason: %s
-
-**NOTE**: This message is automatically generated, if you have questions please ask on #forum-release
-`,
-					pr.PullRequest.Score, pr.PullRequest.DecisionReason)); err != nil {
-					klog.Errorf("Failed to comment on pull request %q: %v", pr.PullRequest.URL, err)
-				}
-			}
+	for _, pr := range skipped {
+		if !r.comment {
 			continue
 		}
+		mergeWindowMsg := ""
+		if config.HasMergeWindow(r.config.MergeWindowConfig) {
+			mergeWindowMsg = fmt.Sprintf(" (%s-%s)", r.config.MergeWindowConfig.From, r.config.MergeWindowConfig.To)
+		}
+		skipCommentMsg := "\n"
+		if len(r.skipComment) > 0 {
+			skipCommentMsg = fmt.Sprintf("\n*%s*\n", r.skipComment)
+		}
+		if err := approver.Comment(ctx, pr.PullRequest.URL, fmt.Sprintf(`
+:hourglass: This pull request was not picked by the patch manager for the current z-stream window and have to wait for the next window%s.
+%s
+* Score: *%0.2f*
+* Reason: *%s*
 
+**NOTE**: This message was automatically generated, if you have questions please ask on #forum-release
+`,
+			mergeWindowMsg, skipCommentMsg, pr.PullRequest.Score, pr.PullRequest.DecisionReason)); err != nil {
+			klog.Errorf("Failed to comment on pull request %q: %v", pr.PullRequest.URL, err)
+		}
+	}
+
+	for _, pr := range approved {
 		fmt.Fprintf(os.Stdout, "-> Approving %s ...\n", pr.PullRequest.URL)
 		if err := approver.CherryPickApprove(ctx, pr.PullRequest.URL); err != nil {
 			klog.Errorf("Failed to approve pull request %q: %v", pr.PullRequest.URL, err)
 		}
 
-		if r.comment {
-			if err := approver.Comment(ctx, pr.PullRequest.URL, fmt.Sprintf("Approved for z-stream by score: %0.2f", pr.PullRequest.Score)); err != nil {
-				klog.Errorf("Failed to comment on pull request %q: %v", pr.PullRequest.URL, err)
-			}
+		if !r.comment {
+			continue
+		}
+		pickCommentMsg := ""
+		if len(r.pickComment) > 0 {
+			pickCommentMsg = fmt.Sprintf("\n\n%s\n", r.pickComment)
+		}
+		if err := approver.Comment(ctx, pr.PullRequest.URL, fmt.Sprintf(":rocket: Approved for z-stream by score: %0.2f%s", pr.PullRequest.Score, pickCommentMsg)); err != nil {
+			klog.Errorf("Failed to comment on pull request %q: %v", pr.PullRequest.URL, err)
 		}
 	}
+	fmt.Println()
 
 	return nil
 }

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -54,12 +54,15 @@ func ComponentCapacity(config *CapacityConfig, name string) (bool, int) {
 	return false, config.MaximumDefaultPicksPerComponent
 }
 
+func HasMergeWindow(c MergeWindowConfig) bool {
+	return len(c.From) > 0 && len(c.To) > 0
+}
+
 func IsMergeWindowOpen(c MergeWindowConfig) bool {
 	// no configuration means always open
-	if len(c.From) == 0 || len(c.To) == 0 {
+	if !HasMergeWindow(c) {
 		return true
 	}
-
 	from, err := time.Parse("2006-01-02", c.From)
 	if err != nil {
 		klog.Warning("Invalid merge window from time configuration: %q, expected format: 2006-01-02 (%s)", c.From, err)


### PR DESCRIPTION
This fixes the malformed PR message (thanks @jwforres for reporting)

There are also two new flags for `approve` command:

`--skip-comment=MSG` - will add a custom comment to ALL skipped PR's (this allows to say "only medium priority picked", etc..)
`--pick-comment=MSG` - will add customer comment to ALL approved PR's