### PR TITLE
config: allow per-release configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,14 @@ Complete implementation and details can be found in `pkg/classifiers` package.
 Each classifier can be configured via `config.yaml` file. Most of them assign "score" to each pull request. The score is additive, so in the example
 below, an "urgent" bug with *TestBlocker* flag will get score `1.8` which will likely put it at the top of the list.
 
+The `releases` directory in this repository contain configuration files for last 3 z-stream releases.
+
 #### Example config.yaml:
 
 ```yaml
 ---
+# Release specify which release this config apply to. Different releases might have different criteria (older releases might be more strict in picking anything below high severity).
+release: 4.7
 # MergeWindow describe a time window when pull requests can be cherry-picked for the z-stream.
 mergeWindow:
   from: # YYYY-MM-DD

--- a/pkg/cmd/approve/approve.go
+++ b/pkg/cmd/approve/approve.go
@@ -182,14 +182,14 @@ func (r *approveOptions) Run(ctx context.Context) error {
 			skipCommentMsg = fmt.Sprintf("\n*%s*\n", r.skipComment)
 		}
 		if err := approver.Comment(ctx, pr.PullRequest.URL, fmt.Sprintf(`
-:hourglass: This pull request was not picked by the patch manager for the current z-stream window and have to wait for the next window%s.
+:hourglass: This pull request was not picked by the patch manager for the current %s z-stream window and have to wait for the next window%s.
 %s
 * Score: *%0.2f*
 * Reason: *%s*
 
 **NOTE**: This message was automatically generated, if you have questions please ask on #forum-release
 `,
-			mergeWindowMsg, skipCommentMsg, pr.PullRequest.Score, pr.PullRequest.DecisionReason)); err != nil {
+			r.config.Release, mergeWindowMsg, skipCommentMsg, pr.PullRequest.Score, pr.PullRequest.DecisionReason)); err != nil {
 			klog.Errorf("Failed to comment on pull request %q: %v", pr.PullRequest.URL, err)
 		}
 	}

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -78,7 +78,7 @@ func (r *runOptions) Validate() error {
 		return fmt.Errorf("github-token flag must be specified or GITHUB_TOKEN environment must be set")
 	}
 	if len(r.release) == 0 {
-		return fmt.Errorf("release flag must be set (eg: --release=4.7)")
+		return fmt.Errorf("release flag must be set (eg: --release=4.7) or release config option")
 	}
 	if r.maxPicks <= 0 {
 		return fmt.Errorf("maxPicks must be above 0")
@@ -104,6 +104,11 @@ func (r *runOptions) Complete() error {
 	r.config, err = config.GetConfig(r.configFile)
 	if err != nil {
 		return fmt.Errorf("unable to get config file %q: %v", r.configFile, err)
+	}
+
+	// If release is not specified via CLI, use the config value
+	if len(r.config.Release) > 0 && len(r.release) == 0 {
+		r.release = r.config.Release
 	}
 
 	r.classifier = classifiers.NewMultiClassifier(

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1,6 +1,7 @@
 package config
 
 type PatchManagerConfig struct {
+	Release            string            `yaml:"release"`
 	CapacityConfig     CapacityConfig    `yaml:"capacity"`
 	ClassifiersConfigs ClassifierConfig  `yaml:"classifiers"`
 	MergeWindowConfig  MergeWindowConfig `yaml:"mergeWindow"`

--- a/releases/4.5.yaml
+++ b/releases/4.5.yaml
@@ -1,0 +1,64 @@
+---
+release: 4.5
+# MergeWindow describe a time window when pull requests can be cherry-picked for the z-stream.
+# Format is: YYYY-MM-DD
+mergeWindow:
+  from:
+  to:
+# Capacity describe the QE capacity for the "next" week per QE group.
+capacity:
+  maxDefaultPicksPerComponent: 3
+  maxTotalPicks: 10
+  groups:
+    - name: Core
+      capacity: 5
+      components:
+      - Master
+      - apiserver-auth
+      - authentication
+      - service-ca
+      - openshift-apiserver
+      - oauth-apiserver
+      - kube-apiserver
+      - oauth-proxy
+      - kube-storage-version-migrator
+      - config-operator
+    - name: Workloads
+      capacity: 5
+      components:
+      - Deployments
+      - Command Line Interface
+      - oc
+      - kube-controller-manager
+      - kube-scheduler
+# Classifiers describe how much score points a single pull request should get. (0-1)
+# Score impact the position of a PR in merge queue.
+classifiers:
+  flags:
+    "TestBlocker": 0.8
+    "UpgradeBlocker": 0.8
+    "Security": 0.5
+  components:
+    "authentication": 0.5
+    "networking": 0.5
+    "node": 0.5
+    "kube-apiserver": 0.5
+  severities:
+    "urgent": 1.0
+    "high": 0.5
+    "medium": -1
+    "low": -1
+    "unknown": -1.0
+  pmScores:
+    - from: 0
+      to: 30
+      score: 0
+    - from: 30
+      to: 50
+      score: 0.2
+    - from: 50
+      to: 100
+      score: 0.5
+    - from: 100
+      to: 999
+      score: 0.8

--- a/releases/4.6.yaml
+++ b/releases/4.6.yaml
@@ -1,0 +1,64 @@
+---
+release: 4.6
+# MergeWindow describe a time window when pull requests can be cherry-picked for the z-stream.
+# Format is: YYYY-MM-DD
+mergeWindow:
+  from:
+  to:
+# Capacity describe the QE capacity for the "next" week per QE group.
+capacity:
+  maxDefaultPicksPerComponent: 5
+  maxTotalPicks: 50
+  groups:
+    - name: Core
+      capacity: 5
+      components:
+      - Master
+      - apiserver-auth
+      - authentication
+      - service-ca
+      - openshift-apiserver
+      - oauth-apiserver
+      - kube-apiserver
+      - oauth-proxy
+      - kube-storage-version-migrator
+      - config-operator
+    - name: Workloads
+      capacity: 5
+      components:
+      - Deployments
+      - Command Line Interface
+      - oc
+      - kube-controller-manager
+      - kube-scheduler
+# Classifiers describe how much score points a single pull request should get. (0-1)
+# Score impact the position of a PR in merge queue.
+classifiers:
+  flags:
+    "TestBlocker": 0.8
+    "UpgradeBlocker": 0.8
+    "Security": 0.5
+  components:
+    "authentication": 0.5
+    "networking": 0.5
+    "node": 0.5
+    "kube-apiserver": 0.5
+  severities:
+    "urgent": 1.0
+    "high": 0.5
+    "medium": 0.2
+    "low": 0.1
+    "unknown": -1.0
+  pmScores:
+    - from: 0
+      to: 30
+      score: 0
+    - from: 30
+      to: 50
+      score: 0.2
+    - from: 50
+      to: 100
+      score: 0.5
+    - from: 100
+      to: 999
+      score: 0.8

--- a/releases/4.7.yaml
+++ b/releases/4.7.yaml
@@ -1,0 +1,64 @@
+---
+release: 4.7
+# MergeWindow describe a time window when pull requests can be cherry-picked for the z-stream.
+# Format is: YYYY-MM-DD
+mergeWindow:
+  from:
+  to:
+# Capacity describe the QE capacity for the "next" week per QE group.
+capacity:
+  maxDefaultPicksPerComponent: 5
+  maxTotalPicks: 50
+  groups:
+    - name: Core
+      capacity: 5
+      components:
+      - Master
+      - apiserver-auth
+      - authentication
+      - service-ca
+      - openshift-apiserver
+      - oauth-apiserver
+      - kube-apiserver
+      - oauth-proxy
+      - kube-storage-version-migrator
+      - config-operator
+    - name: Workloads
+      capacity: 5
+      components:
+      - Deployments
+      - Command Line Interface
+      - oc
+      - kube-controller-manager
+      - kube-scheduler
+# Classifiers describe how much score points a single pull request should get. (0-1)
+# Score impact the position of a PR in merge queue.
+classifiers:
+  flags:
+    "TestBlocker": 0.8
+    "UpgradeBlocker": 0.8
+    "Security": 0.5
+  components:
+    "authentication": 0.5
+    "networking": 0.5
+    "node": 0.5
+    "kube-apiserver": 0.5
+  severities:
+    "urgent": 1.0
+    "high": 0.5
+    "medium": 0.2
+    "low": 0.1
+    "unknown": -1.0
+  pmScores:
+    - from: 0
+      to: 30
+      score: 0
+    - from: 30
+      to: 50
+      score: 0.2
+    - from: 50
+      to: 100
+      score: 0.5
+    - from: 100
+      to: 999
+      score: 0.8


### PR DESCRIPTION
This change allows specifying different configurations for different releases. The `--release` flag is no longer required if one of the configurations inside the `releases/` directory is used.

Different z-stream releases might have different criteria for merging pull requests. This allows to fine-tune classifiers per-release.