### PR TITLE
list: add --approved and --candidates flags to list

### DIFF
--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -139,7 +139,7 @@ func componentName(p []string) string {
 }
 
 func (r *runOptions) Run(ctx context.Context) error {
-	pullsToReview, err := github.NewPullRequestLister(ctx, r.githubToken, r.bugzillaAPIKey).ListForRelease(ctx, r.release)
+	pullsToReview, err := github.NewPullRequestLister(ctx, r.githubToken, r.bugzillaAPIKey).ListCandidatesForRelease(ctx, r.release)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This will add `--approved and `--candidates` flags that require `--release=4.x` set and this will list all PR's that were approved (has cherry-pick label, but not merged yet) 