### PR TITLE
Respect maximum picks value from config.yaml if provided

### DIFF
--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -106,6 +106,10 @@ func (r *runOptions) Complete() error {
 		return fmt.Errorf("unable to get config file %q: %v", r.configFile, err)
 	}
 
+	if r.config.CapacityConfig.MaximumTotalPicks != 0 {
+		r.maxPicks = r.config.CapacityConfig.MaximumTotalPicks
+	}
+
 	r.classifier = classifiers.NewMultiClassifier(
 		&classifiers.SeverityClassifier{Config: &r.config.ClassifiersConfigs.Severities},
 		&classifiers.ComponentClassifier{Config: &r.config.ClassifiersConfigs.ComponentClassifier},


### PR DESCRIPTION
Note: the behavior here is that the config.yaml max picks(if provided) takes precedence over the --max-picks value(if provided), which isn't ideal, but i'm not sure how we can tell whether --max-picks was provided such that we could 

1) use --max-picks if provided
2) if not, use maxpicks from config.yaml if provided
3) if not, use default --max-picks value

Unless we make the --max-picks default value something less "normal", like 0 or -1 so it's obvious the user didn't provide a value.

