### PR TITLE
approve: tweak --skip-comment and --pick-comment and remove --add-comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ items:
    The `decisionReason` field will be used in a comment if `-add-comment` flag is specified (see below).
    
 3. Once you are done editing YAML file, you can run the `patchmanager approve --config=path/to/config.yaml -f candidates.yaml` command which will apply the `cherry-pick-approved` label
-  on ALL pull requests with "pick" decision. Use the `--add-comment` flag if you want to leave a comment with score and reason for every approved or skipped pull request.
+   on ALL pull requests with "pick" decision. If `--skip-comment` or/and `--pick-comment` are set, then a comment will be made to the PR about decision reason. If these are not used,
+   not comment will be made on PR.
    
 4. Alternatively, you can use `patchmanager list -f candidates.yaml` to format the pull requests in human readable table:
 


### PR DESCRIPTION
This PR allow disabling commenting on picked or skipped PR's. If the `--skip-comment` is not used and a custom message is not provided, the tool will not add any comment to PR's that were skipped.

This allows us to run this tool multiple times, perhaps skip some PR's due to capacity, and then on the last day of the merge window, add comments to **all** skipped PR's at once.