### PR TITLE
run: add --use-capacity-percent and remove --max-picks

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ items:
    The `decisionReason` field will be used in a comment if `-add-comment` flag is specified (see below).
    
 3. Once you are done editing YAML file, you can run the `patchmanager approve --config=path/to/config.yaml -f candidates.yaml` command which will apply the `cherry-pick-approved` label
-  on ALL pull requests with "pick" decision. Use the `--add-comment` flag if you want to leave a comment with score and reason for every approved or skipped pull request.
+   on ALL pull requests with "pick" decision. If `--skip-comment` or/and `--pick-comment` are set, then a comment will be made to the PR about decision reason. If these are not used,
+   not comment will be made on PR.
    
 4. Alternatively, you can use `patchmanager list -f candidates.yaml` to format the pull requests in human readable table:
 


### PR DESCRIPTION
This change remove the `--max-picks` flag in favor of the configuration field under capacity config.

Patch managers don't want to exhaust all the capacity during the first day, so we can use `--use-capacity-percent=[0-100]` flag that will derive the percentage of capacity you want to use and take it into account when marking the PR's for "pick".

If capacity is reduced by patch manager `--skip-comment` can be omitted OR patch manager can tell engineers that their PR's will not make it TODAY, but maybe tomorrow. 