### PR TITLE
config: split config per release

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ component will be picked.
 
 * You will need [Github Personal Token](https://github.com/settings/tokens) exported via environment variable `GITHUB_TOKEN` (or use command flag).
 * You will need [Bugzilla API Token](https://bugzilla.redhat.com/userprefs.cgi?tab=apikey) exported via environment variable `BUGZILLA_APIKEY` (or use command flag).
-* You need a config file (check examples/ directory). You can also use `PATCHMANAGER_CONFIG=https://raw.githubusercontent.com/openshift/patchmanager/main/examples/config.yaml`
+* You need a config file (check release/ directory). You can also use `PATCHMANAGER_CONFIG=https://raw.githubusercontent.com/openshift/patchmanager/main/release/4.7.yaml`
 
 ## Installation
 
@@ -109,7 +109,7 @@ The binary `patchmanager` should be installed in your *$GOPATH/bin* directory.
 Alternatively you can use `podman` to run patchmanager. Example:
 
 ```
-podman run -it --env-host quay.io/mfojtik/patchmanager:latest patchmanager run --release=4.7
+podman run -it --env-host quay.io/mfojtik/patchmanager:latest patchmanager run 
 ```
 
 ### Development
@@ -118,7 +118,7 @@ In case you want to contribute, you can use *Makefile* to build the `patchmanage
 
 ## Usage
 
-1. Run `patchmanager run --release=4.x --config=path/to/config.yaml -o candidates.yaml` will produce YAML file of candidate pull request for *4.x* release already sorted
+1. Run `patchmanager run --config=path/to/config.yaml -o candidates.yaml` will produce YAML file of candidate pull request for *4.x* release already sorted
   and scored based on the classifiers. The `capacity` flag will cause that on *N* pull requests will be "picked". (TIP: You can set the `PATCHMANAGER_CONFIG` environment variable
    which points to a config location)
   

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -80,9 +80,6 @@ func (r *runOptions) Validate() error {
 	if len(r.githubToken) == 0 {
 		return fmt.Errorf("github-token flag must be specified or GITHUB_TOKEN environment must be set")
 	}
-	if len(r.release) == 0 {
-		return fmt.Errorf("release flag must be set (eg: --release=4.7)")
-	}
 	if len(r.configFile) == 0 {
 		return fmt.Errorf("need to specify valid config file")
 	}
@@ -107,6 +104,9 @@ func (r *runOptions) Complete() error {
 	r.config, err = config.GetConfig(r.configFile)
 	if err != nil {
 		return fmt.Errorf("unable to get config file %q: %v", r.configFile, err)
+	}
+	if len(r.config.Release) > 0 && len(r.release) == 0 {
+		r.release = r.config.Release
 	}
 
 	r.classifier = classifiers.NewMultiClassifier(

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1,6 +1,7 @@
 package config
 
 type PatchManagerConfig struct {
+	Release            string            `yaml:"release"`
 	CapacityConfig     CapacityConfig    `yaml:"capacity"`
 	ClassifiersConfigs ClassifierConfig  `yaml:"classifiers"`
 	MergeWindowConfig  MergeWindowConfig `yaml:"mergeWindow"`

--- a/release/4.5.yaml
+++ b/release/4.5.yaml
@@ -1,0 +1,181 @@
+---
+release: 4.5
+# MergeWindow describe a time window when pull requests can be cherry-picked for the z-stream.
+# Format is: YYYY-MM-DD
+mergeWindow:
+  from:
+  to:
+# Capacity describe the QE capacity for the "next" week per QE group.
+capacity:
+  maxDefaultPicksPerComponent: 5
+  maxTotalPicks: 50
+  groups:
+    - name: Apiserver and Auth
+      capacity: 7
+      components:
+      - apiserver-auth
+      - service-ca
+      - openshift-apiserver
+      - oauth-apiserver
+      - kube-apiserver
+      - oauth-proxy
+      - kube-storage-version-migrator
+      - config-operator
+    - name: Workloads
+      capacity: 5
+      components:
+      - oc
+      - kube-controller-manager
+      - kube-scheduler
+    - name: Etcd
+      capacity: 3
+      components:
+      - Etcd
+      - Etcd operator
+    - name: Container Engine Tools
+      capacity: 1
+      components:
+      - Containers
+    - name: Node
+      capacity: 5
+      components:
+      - Autoscaler
+      - CPU Manager
+      - CRI-O
+      - Kubelet
+      - Memory manager
+      - Numa aware scheduling
+      - POD resource API
+      - Topology manager
+    - name: Cluster Infrastructure
+      capacity: 6
+      components:
+      - Cloud Compute
+    - name: PSAP
+      capacity: 4
+      components:
+      - Special Resource Operator
+      - ISV Operators
+      - Node Feature Discovery Operator
+      - Node Tuning Operator
+    - name: SDN
+      capacity: 9
+      components:
+      - networking
+    - name: Network Edge
+      capacity: 3
+      components:
+      - routing
+      - dns
+    - name: Storage
+      capacity: 6
+      components:
+      - Storage
+    - name: Logging
+      capacity: 6
+      components:
+      - Logging
+    - name: Build API
+      capacity: 3
+      components:
+      - Build
+      - Openshift-controller-manager
+      - Samples
+      - Templates
+    - name: Admin Console
+      capacity: 8
+      components:
+      - Management Console
+      - Console Metal3 Plugin
+    - name: Cluster Observability
+      capacity: 8
+      components:
+      - Monitoring
+      - Telemeter
+    - name: Metering
+      capacity: 2
+      components:
+      - Metering Operator
+    - name: ISV Operators
+      capacity: 6
+      components:
+      - ISV Operators
+    - name: OLM
+      capacity: 8
+      components:
+      - OLM
+      - OperatorHub
+    - name: Operator SDK
+      capacity: 5
+      components: 
+      - Operator SDK
+    - name: Image Registry
+      capacity: 3
+      components:
+      - Image Registry
+      - ImageStreams
+    - name: Cluster Operator
+      capacity: 3
+      components:
+      - Cloud Credential Operator
+      - Hive
+    - name: Installer
+      capacity: 8
+      components:
+      - Installer
+    - name: Over the Air
+      capacity: 3
+      components:
+      - Cluster Version Operator
+      - Openshift Update Service
+    - name: Windows Containers
+      capacity: 3
+      components:
+      - Windows Containers
+    - name: RHCOS
+      capacity: 1
+      components:
+      - RHCOS
+    - name: MCO
+      capacity: 1
+      components:
+      - Machine Config Operator
+    - name: Infrastructure Security and Compliance
+      capacity: 5
+      components:
+      - Compliance Operator
+      - File Integrity Operator
+# Classifiers describe how much score points a single pull request should get. (0-1)
+# Score impact the position of a PR in merge queue.
+classifiers:
+  keywords:
+    "TestBlocker": 0.8
+    "UpgradeBlocker": 0.8
+    "ServiceDeliveryBlocker": 0.8
+    "Security": 0.5
+    "ServiceDeliveryImpact": 0.4
+    "FastFix": 1.0
+  components:
+    "authentication": 0.5
+    "networking": 0.5
+    "node": 0.5
+    "kube-apiserver": 0.5
+  severities:
+    "urgent": 1.0
+    "high": 0.5
+    "medium": 0.2
+    "low": 0.1
+    "unknown": -1.0
+  pmScores:
+    - from: 0
+      to: 30
+      score: 0
+    - from: 30
+      to: 50
+      score: 0.2
+    - from: 50
+      to: 100
+      score: 0.5
+    - from: 100
+      to: 999
+      score: 0.8

--- a/release/4.6.yaml
+++ b/release/4.6.yaml
@@ -1,0 +1,181 @@
+---
+release: 4.6
+# MergeWindow describe a time window when pull requests can be cherry-picked for the z-stream.
+# Format is: YYYY-MM-DD
+mergeWindow:
+  from:
+  to:
+# Capacity describe the QE capacity for the "next" week per QE group.
+capacity:
+  maxDefaultPicksPerComponent: 5
+  maxTotalPicks: 50
+  groups:
+    - name: Apiserver and Auth
+      capacity: 7
+      components:
+      - apiserver-auth
+      - service-ca
+      - openshift-apiserver
+      - oauth-apiserver
+      - kube-apiserver
+      - oauth-proxy
+      - kube-storage-version-migrator
+      - config-operator
+    - name: Workloads
+      capacity: 5
+      components:
+      - oc
+      - kube-controller-manager
+      - kube-scheduler
+    - name: Etcd
+      capacity: 3
+      components:
+      - Etcd
+      - Etcd operator
+    - name: Container Engine Tools
+      capacity: 1
+      components:
+      - Containers
+    - name: Node
+      capacity: 5
+      components:
+      - Autoscaler
+      - CPU Manager
+      - CRI-O
+      - Kubelet
+      - Memory manager
+      - Numa aware scheduling
+      - POD resource API
+      - Topology manager
+    - name: Cluster Infrastructure
+      capacity: 6
+      components:
+      - Cloud Compute
+    - name: PSAP
+      capacity: 4
+      components:
+      - Special Resource Operator
+      - ISV Operators
+      - Node Feature Discovery Operator
+      - Node Tuning Operator
+    - name: SDN
+      capacity: 9
+      components:
+      - networking
+    - name: Network Edge
+      capacity: 3
+      components:
+      - routing
+      - dns
+    - name: Storage
+      capacity: 6
+      components:
+      - Storage
+    - name: Logging
+      capacity: 6
+      components:
+      - Logging
+    - name: Build API
+      capacity: 3
+      components:
+      - Build
+      - Openshift-controller-manager
+      - Samples
+      - Templates
+    - name: Admin Console
+      capacity: 8
+      components:
+      - Management Console
+      - Console Metal3 Plugin
+    - name: Cluster Observability
+      capacity: 8
+      components:
+      - Monitoring
+      - Telemeter
+    - name: Metering
+      capacity: 2
+      components:
+      - Metering Operator
+    - name: ISV Operators
+      capacity: 6
+      components:
+      - ISV Operators
+    - name: OLM
+      capacity: 8
+      components:
+      - OLM
+      - OperatorHub
+    - name: Operator SDK
+      capacity: 5
+      components: 
+      - Operator SDK
+    - name: Image Registry
+      capacity: 3
+      components:
+      - Image Registry
+      - ImageStreams
+    - name: Cluster Operator
+      capacity: 3
+      components:
+      - Cloud Credential Operator
+      - Hive
+    - name: Installer
+      capacity: 8
+      components:
+      - Installer
+    - name: Over the Air
+      capacity: 3
+      components:
+      - Cluster Version Operator
+      - Openshift Update Service
+    - name: Windows Containers
+      capacity: 3
+      components:
+      - Windows Containers
+    - name: RHCOS
+      capacity: 1
+      components:
+      - RHCOS
+    - name: MCO
+      capacity: 1
+      components:
+      - Machine Config Operator
+    - name: Infrastructure Security and Compliance
+      capacity: 5
+      components:
+      - Compliance Operator
+      - File Integrity Operator
+# Classifiers describe how much score points a single pull request should get. (0-1)
+# Score impact the position of a PR in merge queue.
+classifiers:
+  keywords:
+    "TestBlocker": 0.8
+    "UpgradeBlocker": 0.8
+    "ServiceDeliveryBlocker": 0.8
+    "Security": 0.5
+    "ServiceDeliveryImpact": 0.4
+    "FastFix": 1.0
+  components:
+    "authentication": 0.5
+    "networking": 0.5
+    "node": 0.5
+    "kube-apiserver": 0.5
+  severities:
+    "urgent": 1.0
+    "high": 0.5
+    "medium": 0.2
+    "low": 0.1
+    "unknown": -1.0
+  pmScores:
+    - from: 0
+      to: 30
+      score: 0
+    - from: 30
+      to: 50
+      score: 0.2
+    - from: 50
+      to: 100
+      score: 0.5
+    - from: 100
+      to: 999
+      score: 0.8

--- a/release/4.7.yaml
+++ b/release/4.7.yaml
@@ -1,4 +1,5 @@
 ---
+release: 4.7
 # MergeWindow describe a time window when pull requests can be cherry-picked for the z-stream.
 # Format is: YYYY-MM-DD
 mergeWindow:


### PR DESCRIPTION
This change splits the `examples/config.yaml` per release (4.5, 4.6, 4.7, ...)
This also makes `--release` flags for `list` and `run` commands optional (it override the release field inside config). 