### PR TITLE
Add initial support for rule engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Complete implementation and details can be found in `pkg/classifiers` package.
 Each classifier can be configured via `config.yaml` file. Most of them assign "score" to each pull request. The score is additive, so in the example
 below, an "urgent" bug with *TestBlocker* keyword will get score `1.8` which will likely put it at the top of the list.
 
-#### Example config.yaml:
+#### Example release config YAML:
 
 ```yaml
 ---
@@ -48,6 +48,13 @@ capacity:
       - oc
       - kube-controller-manager
       - kube-scheduler
+# Rules specify go/no-go rules to apply on every PR. These rules does not use classification/scoring, but make decisions directly
+# based on conditions
+rules:
+  labels:
+    # Refuse lists pull request label prefixes that when found the pull request will be automatically "skipped" (reason will be recorded)
+    refuse:
+      - do-no-merge/hold
 # Classifiers describe how much score points a single pull request should get. (0-1)
 # Score impact the position of a PR in merge queue.
 classifiers:

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -4,6 +4,7 @@ type PatchManagerConfig struct {
 	Release            string            `yaml:"release"`
 	CapacityConfig     CapacityConfig    `yaml:"capacity"`
 	ClassifiersConfigs ClassifierConfig  `yaml:"classifiers"`
+	RulesConfig        RulesConfig       `yaml:"rules"`
 	MergeWindowConfig  MergeWindowConfig `yaml:"mergeWindow"`
 }
 
@@ -19,10 +20,17 @@ type MergeWindowConfig struct {
 	To   string `yaml:"to,omitempty"`
 }
 
+type RulesConfig struct {
+	PullRequestLabelConfig PullRequestLabelRuleConfig `yaml:"labels"`
+}
+
+type PullRequestLabelRuleConfig struct {
+	RefuseOnLabel []string `yaml:"refuse"`
+}
+
 type KeywordsClassifierConfig map[string]float32
 type ComponentClassifierConfig map[string]float32
 type SeverityClassifierConfig map[string]float32
-
 type PMScoreClassifierConfig []PMScoreRange
 
 type PMScoreRange struct {

--- a/pkg/rule/pull_request_label_rule.go
+++ b/pkg/rule/pull_request_label_rule.go
@@ -1,0 +1,25 @@
+package rule
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/patchmanager/pkg/config"
+	"github.com/openshift/patchmanager/pkg/github"
+)
+
+type PullRequestLabelRule struct {
+	Config *config.PullRequestLabelRuleConfig
+}
+
+func (p *PullRequestLabelRule) Evaluate(pullRequest *github.PullRequest) ([]string, bool) {
+	result := []string{}
+	for _, l := range pullRequest.Issue.Labels {
+		for _, c := range p.Config.RefuseOnLabel {
+			if strings.HasPrefix(l.GetName(), c) {
+				result = append(result, fmt.Sprintf("skipping because %q label found", l.GetName()))
+			}
+		}
+	}
+	return result, len(result) == 0
+}

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -1,0 +1,28 @@
+package rule
+
+import "github.com/openshift/patchmanager/pkg/github"
+
+type Ruler interface {
+	Evaluate(*github.PullRequest) ([]string, bool)
+}
+
+type MultiRuler struct {
+	rulers []Ruler
+}
+
+func (m *MultiRuler) Evaluate(pullRequest *github.PullRequest) ([]string, bool) {
+	decisions := []string{}
+	result := true
+	for i := range m.rulers {
+		messages, pass := m.rulers[i].Evaluate(pullRequest)
+		if !pass {
+			decisions = append(decisions, messages...)
+			result = false
+		}
+	}
+	return decisions, result
+}
+
+func NewMultiRuler(rullers ...Ruler) Ruler {
+	return &MultiRuler{rulers: rullers}
+}

--- a/release/4.7.yaml
+++ b/release/4.7.yaml
@@ -145,6 +145,10 @@ capacity:
       components:
       - Compliance Operator
       - File Integrity Operator
+rules:
+  labels:
+    refuse:
+      - do-not-merge/
 # Classifiers describe how much score points a single pull request should get. (0-1)
 # Score impact the position of a PR in merge queue.
 classifiers:


### PR DESCRIPTION
As discussed in patch manager sync, in some cases the classification system is not ideal, especially when making go/no-go decisions on pull requests. 
For example, if a pull request is "on hold" (has do-not-merge/hold label), then we want to automatically skip such pull request with a reason recorded in the comment.
The rule engine here allows writing "rules" that evaluate pull requests and result in "go/no-go" decision and a list of messages describing this decision.

```
patchmanager [split-release L|●2✚ 5⚑ 1] > ./patchmanager run --config=release/4.7.yaml
I0517 15:43:51.055592   99771 run.go:128] Using 100% of total QE capacity of 50 PR's approved for ALL z-stream releases (max. 50 picked)
I0517 15:43:53.180369   99771 run.go:163] Capacity configuration for 26 groups loaded (default per component: 5)
I0517 15:43:53.180563   99771 run.go:175] Wait to finish classifying 31 z-stream candidate pull requests ...
31 / 31 [---------------------------------------------------------------------------------------------------------------------------------------] 100.00% 2 p/s
I0517 15:44:10.408105   99771 run.go:202] 2 pull requests refused by the rules

  COMPONENT NAME (13)        TOTAL   PICKS   SKIPS  
 -------------------------- ------- ------- ------- 
  cluster version operator       1       1       0  
  etcd                           1       1       0  
  routing                        1       1       0  
  cloud compute                  1       1       0  
  image registry                 2       2       0  
  monitoring                     3       3       0  
  olm                            1       1       0  
  networking                     5       5       0  
  dev console                    4       4       0  
  management console             3       3       0  
  console storage plugin         3       3       0  
  node tuning operator           1       1       0  
  installer                      3       3       0  

items:
- pullRequest:
    # Description: OperatorHub - console accepts any value for "Infrastructure features"
    # annotation
    # Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1957499
    # Component: management console
    # Severity: medium
    # PM Score 25
    url: https://github.com/openshift/console/pull/8859
    decision: skip
    score: 0.2
    decisionReason: skipping because "do-not-merge/hold" label found

```