### PR TITLE
Allow releases to skip PRs based on severity and provide useful comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ rules:
     # Refuse lists pull request label prefixes that when found the pull request will be automatically "skipped" (reason will be recorded)
     refuse:
       - do-not-merge/hold
+      # This section can also be used to inform PRs that their bug severity is not high enough 
+      # for a given release branch. Here, by excluding lower severities, 
+      # only severity-high and severity-urgent will be permitted.
+      - bugzilla/severity-unspecified
+      - bugzilla/severity-low
+      - bugzilla/severity-medium
 # Classifiers describe how much score points a single pull request should get. (0-1)
 # Score impact the position of a PR in merge queue.
 classifiers:

--- a/pkg/rule/pull_request_label_rule.go
+++ b/pkg/rule/pull_request_label_rule.go
@@ -21,5 +21,8 @@ func (p *PullRequestLabelRule) Evaluate(pullRequest *github.PullRequest) ([]stri
 			}
 		}
 	}
+	if len(result) != 0 {
+		result = append(result, fmt.Sprintf("one or more labels has prevented approval; any of the following labels will preclude this PR from being approved: %v", p.Config.RefuseOnLabel))
+	}
 	return result, len(result) == 0
 }

--- a/release/4.5.yaml
+++ b/release/4.5.yaml
@@ -11,8 +11,12 @@ rules:
   labels:
     # Refuse lists pull request label prefixes that when found the pull request will be automatically "skipped" (reason will be recorded)
     refuse:
-      - do-not-merge/hold
+      - do-not-merge/
       - needs-rebase
+      - bugzilla/severity-unspecified
+      - bugzilla/severity-low
+      - bugzilla/severity-medium
+      - bugzilla/severity-high
 # Capacity describe the QE capacity for the "next" week per QE group.
 capacity:
   maxDefaultPicksPerComponent: 5

--- a/release/4.6.yaml
+++ b/release/4.6.yaml
@@ -11,8 +11,12 @@ rules:
   labels:
     # Refuse lists pull request label prefixes that when found the pull request will be automatically "skipped" (reason will be recorded)
     refuse:
-      - do-not-merge/hold
+      - do-not-merge/
       - needs-rebase
+      # 4.6 is limited to high & urgent severity backports
+      - bugzilla/severity-unspecified
+      - bugzilla/severity-low
+      - bugzilla/severity-medium
 # Capacity describe the QE capacity for the "next" week per QE group.
 capacity:
   maxDefaultPicksPerComponent: 5

--- a/release/4.7.yaml
+++ b/release/4.7.yaml
@@ -11,7 +11,7 @@ rules:
   labels:
     # Refuse lists pull request label prefixes that when found the pull request will be automatically "skipped" (reason will be recorded)
     refuse:
-      - do-not-merge/hold
+      - do-not-merge/
       - needs-rebase
 # Capacity describe the QE capacity for the "next" week per QE group.
 capacity:
@@ -153,10 +153,6 @@ capacity:
       components:
       - Compliance Operator
       - File Integrity Operator
-rules:
-  labels:
-    refuse:
-      - do-not-merge/
 # Classifiers describe how much score points a single pull request should get. (0-1)
 # Score impact the position of a PR in merge queue.
 classifiers:

--- a/release/4.8.yaml
+++ b/release/4.8.yaml
@@ -11,7 +11,7 @@ rules:
   labels:
     # Refuse lists pull request label prefixes that when found the pull request will be automatically "skipped" (reason will be recorded)
     refuse:
-      - do-not-merge/hold
+      - do-not-merge/
       - needs-rebase
 # Capacity describe the QE capacity for the "next" week per QE group.
 capacity:
@@ -153,10 +153,6 @@ capacity:
       components:
       - Compliance Operator
       - File Integrity Operator
-rules:
-  labels:
-    refuse:
-      - do-not-merge/
 # Classifiers describe how much score points a single pull request should get. (0-1)
 # Score impact the position of a PR in merge queue.
 classifiers:


### PR DESCRIPTION
Allows us to skip PRs based on invalid bug severity for a given release (e.g. 4.6 is in maintenance currently and we should only be approving high & urgent bugs). While this was possible with the previous implementation of the `refuse` rule, it would not have provided guidance to the issue owner on which severity _would_ allow it to merge. This PR adds to the refusal comment a full list of disallowed labels so that they can deduce the necessary severity. 

Example yaml output:
```yaml
    decisionReason: 'skipping because "bugzilla/severity-medium" label found, one
      or more labels has prevented approval; any of the following labels will preclude
      this PR from being approved: [do-not-merge/ needs-rebase bugzilla/severity-unspecified
      bugzilla/severity-low bugzilla/severity-medium]'
```

Also includes:
- all skips in stdout table in order to fully capture what it included in the output yaml
- adds a TOTALS line to tabular stdout
- eliminates erroneous extra rules stanzas in some configs
