### PR TITLE
list: add tide status to approved list

### DIFF
--- a/pkg/github/pull_request.go
+++ b/pkg/github/pull_request.go
@@ -6,7 +6,7 @@ import (
 )
 
 type PullRequest struct {
-	Issue github.Issue
+	Issue *github.Issue
 	Score float32
 
 	// do lazy fetch for bugs when needed to speed up sorting


### PR DESCRIPTION
This adds tide status into the list approved to spot stuck PR's faster.

Example: https://gist.githubusercontent.com/mfojtik/fc66254253e728b0b1b5aa838aa29efe/raw/f20cc8a8d65979e22c81c5aed8072bef7e4c6b6f/gistfile1.txt