### PR TITLE
require backport-risk-assessed labels for 4.6-4.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,12 @@ go 1.15
 
 require (
 	github.com/cheggaaa/pb/v3 v3.0.6
-	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/dustin/go-humanize v1.0.0
 	github.com/enriquebris/goconcurrentcounter v0.0.0-20210303202617-b0fccc15d4ea // indirect
 	github.com/enriquebris/goconcurrentqueue v0.6.0 // indirect
 	github.com/enriquebris/goworkerpool v0.10.0
 	github.com/eparis/bugzilla v0.0.0-20210108140723-998a521ca0b5
+	github.com/fatih/color v1.7.0
 	github.com/google/go-github/v32 v32.1.0
 	github.com/kataras/tablewriter v0.0.0-20180708051242-e063d29b7c23 // indirect
 	github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -26,6 +26,7 @@ type RulesConfig struct {
 
 type PullRequestLabelRuleConfig struct {
 	RefuseOnLabel []string `yaml:"refuse"`
+	RequireLabel  []string `yaml:"require"`
 }
 
 type KeywordsClassifierConfig map[string]float32

--- a/pkg/rule/pull_request_label_rule.go
+++ b/pkg/rule/pull_request_label_rule.go
@@ -21,5 +21,20 @@ func (p *PullRequestLabelRule) Evaluate(pullRequest *github.PullRequest) ([]stri
 			}
 		}
 	}
+
+	for _, c := range p.Config.RequireLabel {
+		found := false
+		for _, l := range pullRequest.Issue.Labels {
+			if strings.HasPrefix(l.GetName(), c) {
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+		result = append(result, fmt.Sprintf("skipping because %q label was not found", c))
+	}
+
 	return result, len(result) == 0
 }

--- a/release/4.6.yaml
+++ b/release/4.6.yaml
@@ -13,6 +13,8 @@ rules:
     refuse:
       - do-not-merge/hold
       - needs-rebase
+    require:
+      - backport-risk-assessed
 # Capacity describe the QE capacity for the "next" week per QE group.
 capacity:
   maxDefaultPicksPerComponent: 5

--- a/release/4.7.yaml
+++ b/release/4.7.yaml
@@ -13,6 +13,8 @@ rules:
     refuse:
       - do-not-merge/hold
       - needs-rebase
+    require:
+      - backport-risk-assessed
 # Capacity describe the QE capacity for the "next" week per QE group.
 capacity:
   maxDefaultPicksPerComponent: 5

--- a/release/4.8.yaml
+++ b/release/4.8.yaml
@@ -13,6 +13,8 @@ rules:
     refuse:
       - do-not-merge/hold
       - needs-rebase
+    require:
+      - backport-risk-assessed
 # Capacity describe the QE capacity for the "next" week per QE group.
 capacity:
   maxDefaultPicksPerComponent: 5

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -24,6 +24,7 @@ github.com/enriquebris/goworkerpool
 ## explicit
 github.com/eparis/bugzilla
 # github.com/fatih/color v1.7.0
+## explicit
 github.com/fatih/color
 # github.com/go-logr/logr v0.2.0
 github.com/go-logr/logr


### PR DESCRIPTION
This also includes the build changes from #39 